### PR TITLE
Fix NumPy 2.x compatibility issues

### DIFF
--- a/INSTALL_TROUBLESHOOTING.md
+++ b/INSTALL_TROUBLESHOOTING.md
@@ -10,6 +10,22 @@ This guide helps resolve common installation issues with the Personal AI Retriev
 
 **Solution Options**:
 
+### 2. NumPy 2.x Compatibility Issues
+
+**Error**: `A module that was compiled using NumPy 1.x cannot be run in NumPy 2.3.3 as it may crash`
+
+**Solution**: Downgrade NumPy to 1.x
+```bash
+pip install "numpy<2.0.0"
+# Then reinstall other packages
+pip install --force-reinstall torch sentence-transformers
+```
+
+**Alternative**: Use the fixed requirements
+```bash
+pip install -r requirements.txt  # Now includes numpy<2.0.0
+```
+
 #### Option A: Use Minimal Requirements (Recommended for Quick Start)
 ```bash
 # Install minimal dependencies (no local embeddings)
@@ -201,6 +217,7 @@ If you continue to have issues:
 | Error | Solution |
 |-------|----------|
 | `No module named 'torch'` | Install PyTorch first: `pip install torch` |
+| `NumPy 1.x cannot be run in NumPy 2.x` | Downgrade NumPy: `pip install "numpy<2.0.0"` |
 | `Microsoft Visual C++ 14.0 is required` (Windows) | Install Visual Studio Build Tools |
 | `Failed building wheel for chromadb` | Install build tools: `pip install wheel setuptools` |
 | `No module named 'sentence_transformers'` | Use minimal requirements or install PyTorch first |

--- a/fix_numpy.py
+++ b/fix_numpy.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+Quick fix script for NumPy 2.x compatibility issues.
+Run this if you encounter NumPy compatibility errors.
+"""
+
+import subprocess
+import sys
+
+def run_command(cmd):
+    """Run a command and print the output."""
+    print(f"Running: {cmd}")
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Error: {result.stderr}")
+        return False
+    print(f"Success: {result.stdout}")
+    return True
+
+def main():
+    print("🔧 Fixing NumPy 2.x compatibility issues...")
+    print("=" * 50)
+    
+    # Step 1: Downgrade NumPy
+    print("\n1. Downgrading NumPy to 1.x...")
+    if not run_command('pip install "numpy<2.0.0"'):
+        print("❌ Failed to downgrade NumPy")
+        return 1
+    
+    # Step 2: Reinstall PyTorch
+    print("\n2. Reinstalling PyTorch...")
+    if not run_command('pip install --force-reinstall torch torchvision torchaudio'):
+        print("❌ Failed to reinstall PyTorch")
+        return 1
+    
+    # Step 3: Reinstall sentence-transformers
+    print("\n3. Reinstalling sentence-transformers...")
+    if not run_command('pip install --force-reinstall sentence-transformers'):
+        print("❌ Failed to reinstall sentence-transformers")
+        return 1
+    
+    # Step 4: Test the fix
+    print("\n4. Testing the fix...")
+    try:
+        import numpy
+        import torch
+        import sentence_transformers
+        print(f"✅ NumPy version: {numpy.__version__}")
+        print(f"✅ PyTorch version: {torch.__version__}")
+        print(f"✅ Sentence-transformers version: {sentence_transformers.__version__}")
+        
+        # Test basic functionality
+        from sentence_transformers import SentenceTransformer
+        print("✅ SentenceTransformer import successful")
+        
+    except Exception as e:
+        print(f"❌ Test failed: {e}")
+        return 1
+    
+    print("\n🎉 NumPy compatibility fix completed successfully!")
+    print("\nYou can now run:")
+    print("  python test_core.py")
+    print("  pai-assistant status")
+    
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ rich>=13.0.0
 
 # Vector database and embeddings
 chromadb>=0.4.0,<1.2.0
+numpy>=1.21.0,<2.0.0
 torch>=1.11.0,<3.0.0
 sentence-transformers>=2.2.0,<6.0.0
 openai>=1.0.0

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     ],
     extras_require={
         "full": [
+            "numpy>=1.21.0,<2.0.0",
             "torch>=1.11.0,<3.0.0",
             "sentence-transformers>=2.2.0,<6.0.0",
             "langchain>=0.1.0,<0.4.0",


### PR DESCRIPTION
- Pin NumPy to <2.0.0 to avoid compatibility issues with PyTorch/sentence-transformers
- Add NumPy version constraint to requirements.txt and setup.py
- Update troubleshooting guide with NumPy 2.x solutions
- Create fix_numpy.py script for quick resolution of existing installations

Fixes the error:
'A module that was compiled using NumPy 1.x cannot be run in NumPy 2.3.3'

This ensures compatibility with:
- PyTorch compiled with NumPy 1.x
- sentence-transformers dependencies
- All ML packages in the ecosystem
